### PR TITLE
fixes #93

### DIFF
--- a/ChatTranslated/Translate/LLMTranslate.cs
+++ b/ChatTranslated/Translate/LLMTranslate.cs
@@ -20,8 +20,7 @@ internal static partial class OpenAITranslate
     [GeneratedRegex(@"#### Translation\s*\n(.+)$", RegexOptions.Singleline)]
     private static partial Regex TranslationSectionRegex();
 
-    [GeneratedRegex(@"\s*CONTEXT\s*\(Use if relevant\)\s*:.*$", RegexOptions.Singleline)]
-    private static partial Regex EchoedContextRegex();
+    private const int MaxTranslationLines = 4;
 
     public static async Task<(string, TranslationMode?)> Translate(Message message, string targetLanguage
         , string baseUrl = "https://api.openai.com/v1/chat/completions", string model = "gpt-5-mini", string? apiKey = null)
@@ -76,8 +75,14 @@ internal static partial class OpenAITranslate
             var translationMatch = TranslationSectionRegex().Match(translated);
             translated = translationMatch.Success ? translationMatch.Groups[1].Value.Trim() : translated;
 
-            // Strip any echoed CONTEXT block that the LLM may have repeated from the prompt
-            translated = EchoedContextRegex().Replace(translated, string.Empty).Trim();
+            // If the response has too many lines, the LLM likely echoed prompt content;
+            // take only the text before the first blank line as the actual translation.
+            if (translated.Split('\n').Length >= MaxTranslationLines)
+            {
+                var trimmed = translated.Split("\n\n", 2)[0].Trim();
+                if (!trimmed.IsNullOrWhitespace())
+                    translated = trimmed;
+            }
 
             return (translated, TranslationMode.OpenAI);
         }

--- a/ChatTranslated/Translate/LLMTranslate.cs
+++ b/ChatTranslated/Translate/LLMTranslate.cs
@@ -20,6 +20,9 @@ internal static partial class OpenAITranslate
     [GeneratedRegex(@"#### Translation\s*\n(.+)$", RegexOptions.Singleline)]
     private static partial Regex TranslationSectionRegex();
 
+    [GeneratedRegex(@"\s*CONTEXT\s*\(Use if relevant\)\s*:.*$", RegexOptions.Singleline)]
+    private static partial Regex EchoedContextRegex();
+
     public static async Task<(string, TranslationMode?)> Translate(Message message, string targetLanguage
         , string baseUrl = "https://api.openai.com/v1/chat/completions", string model = "gpt-5-mini", string? apiKey = null)
     {
@@ -72,6 +75,9 @@ internal static partial class OpenAITranslate
 
             var translationMatch = TranslationSectionRegex().Match(translated);
             translated = translationMatch.Success ? translationMatch.Groups[1].Value.Trim() : translated;
+
+            // Strip any echoed CONTEXT block that the LLM may have repeated from the prompt
+            translated = EchoedContextRegex().Replace(translated, string.Empty).Trim();
 
             return (translated, TranslationMode.OpenAI);
         }

--- a/ChatTranslated/Translate/LLMTranslate.cs
+++ b/ChatTranslated/Translate/LLMTranslate.cs
@@ -20,8 +20,6 @@ internal static partial class OpenAITranslate
     [GeneratedRegex(@"#### Translation\s*\n(.+)$", RegexOptions.Singleline)]
     private static partial Regex TranslationSectionRegex();
 
-    private const int MaxTranslationLines = 4;
-
     public static async Task<(string, TranslationMode?)> Translate(Message message, string targetLanguage
         , string baseUrl = "https://api.openai.com/v1/chat/completions", string model = "gpt-5-mini", string? apiKey = null)
     {
@@ -75,11 +73,10 @@ internal static partial class OpenAITranslate
             var translationMatch = TranslationSectionRegex().Match(translated);
             translated = translationMatch.Success ? translationMatch.Groups[1].Value.Trim() : translated;
 
-            // If the response has too many lines, the LLM likely echoed prompt content;
-            // take only the text before the first blank line as the actual translation.
-            if (translated.Split('\n').Length >= MaxTranslationLines)
+            // LLM likely generated slop
+            if (translated.Split('\n').Length >= 4)
             {
-                var trimmed = translated.Split("\n\n", 2)[0].Trim();
+                var trimmed = translated.Split("\n\n", 2)[0].Trim();  // take the first part and call it a day
                 if (!trimmed.IsNullOrWhitespace())
                     translated = trimmed;
             }


### PR DESCRIPTION
in LLM translations, take the first part of generated text if captured translation > 3 lines