### PR TITLE
feat(cache): persist LRU translation cache to disk

### DIFF
--- a/ChatTranslated/Plugin.cs
+++ b/ChatTranslated/Plugin.cs
@@ -102,6 +102,7 @@ public sealed class Plugin : IDalamudPlugin
         }
 
         _ = LanguageDetector.RebuildDetectorAsync();
+        TranslationHandler.LoadCache();
     }
 
     private void OnContextMenuOpened(IMenuOpenedArgs args)
@@ -174,6 +175,7 @@ public sealed class Plugin : IDalamudPlugin
     {
         IpcManager.Unregister();
         Translate.LanguageDetector.Dispose();
+        Translate.TranslationHandler.SaveCache();
         Translate.TranslationHandler.HttpClient.Dispose();
 
         WindowSystem.RemoveAllWindows();

--- a/ChatTranslated/Translate/TranslationHandler.cs
+++ b/ChatTranslated/Translate/TranslationHandler.cs
@@ -2,10 +2,12 @@ using ChatTranslated.Chat;
 using ChatTranslated.Utils;
 using Dalamud.Networking.Http;
 using System;
-using System.Collections.Concurrent;
-using System.Linq;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ChatTranslated.Translate;
@@ -24,16 +26,84 @@ internal static class TranslationHandler
     };
 
     private const int MAX_CACHE_SIZE = 120;
-    public static readonly ConcurrentDictionary<string, string> TranslationCache = [];
+
+    private static readonly LinkedList<KeyValuePair<string, string>> TranslationCache = new();
+    private static readonly Dictionary<string, LinkedListNode<KeyValuePair<string, string>>> TranslationCacheIndex = [];
+    private static readonly Lock TranslationCacheLock = new();
+
+    private static string CacheFilePath =>
+        Path.Combine(Service.pluginInterface.ConfigDirectory.FullName, "translation_cache.json");
+
+    public static void LoadCache()
+    {
+        try
+        {
+            var path = CacheFilePath;
+            if (!File.Exists(path)) return;
+
+            var json = File.ReadAllText(path);
+            var entries = JsonSerializer.Deserialize<List<string[]>>(json);
+            if (entries == null) return;
+
+            // Only keep the most recent MAX_CACHE_SIZE entries
+            if (entries.Count > MAX_CACHE_SIZE)
+                entries = entries.GetRange(entries.Count - MAX_CACHE_SIZE, MAX_CACHE_SIZE);
+
+            lock (TranslationCacheLock)
+            {
+                TranslationCache.Clear();
+                TranslationCacheIndex.Clear();
+                foreach (var pair in entries)
+                {
+                    if (pair.Length != 2 || TranslationCacheIndex.ContainsKey(pair[0])) continue;
+                    var node = TranslationCache.AddLast(new KeyValuePair<string, string>(pair[0], pair[1]));
+                    TranslationCacheIndex[pair[0]] = node;
+                }
+            }
+
+            Service.pluginLog.Information($"[TranslationHandler] Loaded {TranslationCacheIndex.Count} cache entries.");
+        }
+        catch (Exception ex)
+        {
+            Service.pluginLog.Warning($"[TranslationHandler] Failed to load cache: {ex.Message}");
+        }
+    }
+
+    public static void SaveCache()
+    {
+        try
+        {
+            List<string[]> snapshot;
+            lock (TranslationCacheLock)
+            {
+                snapshot = new List<string[]>(TranslationCache.Count);
+                foreach (var kv in TranslationCache)
+                    snapshot.Add([kv.Key, kv.Value]);
+            }
+
+            var path = CacheFilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(snapshot));
+        }
+        catch (Exception ex)
+        {
+            Service.pluginLog.Warning($"[TranslationHandler] Failed to save cache: {ex.Message}");
+        }
+    }
 
     public static async Task<Message> TranslateMessage(Message message, string targetLanguage = null!)
     {
         targetLanguage ??= Service.configuration.EffectiveTargetLanguage;
 
-        if (TranslationCache.TryGetValue(message.OriginalText, out var cachedTranslation))
+        lock (TranslationCacheLock)
         {
-            message.TranslatedContent = cachedTranslation;
-            return message;
+            if (TranslationCacheIndex.TryGetValue(message.OriginalText, out var cachedNode))
+            {
+                TranslationCache.Remove(cachedNode);
+                TranslationCache.AddLast(cachedNode);
+                message.TranslatedContent = cachedNode.Value.Value;
+                return message;
+            }
         }
 
         var (translatedText, mode) = Service.configuration.UseCustomLanguage
@@ -57,17 +127,45 @@ internal static class TranslationHandler
         if (message.Source != MessageSource.MainWindow
             && message.TranslationMode != Configuration.TranslationMode.MachineTranslate)
         {
-            if (TranslationCache.Count >= MAX_CACHE_SIZE)
+            bool added;
+            lock (TranslationCacheLock)
             {
-                foreach (var key in TranslationCache.Keys.Take(MAX_CACHE_SIZE / 2))
-                    TranslationCache.TryRemove(key, out _);
+                if (TranslationCacheIndex.TryGetValue(message.OriginalText, out var existingNode))
+                {
+                    TranslationCache.Remove(existingNode);
+                    TranslationCache.AddLast(existingNode);
+                    added = false;
+                }
+                else
+                {
+                    if (TranslationCacheIndex.Count >= MAX_CACHE_SIZE)
+                    {
+                        var oldest = TranslationCache.First!;
+                        TranslationCache.RemoveFirst();
+                        TranslationCacheIndex.Remove(oldest.Value.Key);
+                    }
+
+                    var node = TranslationCache.AddLast(new KeyValuePair<string, string>(message.OriginalText, translatedText));
+                    TranslationCacheIndex[message.OriginalText] = node;
+                    added = true;
+                }
             }
 
-            TranslationCache.TryAdd(message.OriginalText, translatedText);
+            if (added)
+                _ = Task.Run(SaveCache);
         }
 
         return message;
     }
 
-    public static void ClearTranslationCache() => TranslationCache.Clear();
+    public static void ClearTranslationCache()
+    {
+        lock (TranslationCacheLock)
+        {
+            TranslationCache.Clear();
+            TranslationCacheIndex.Clear();
+        }
+
+        _ = Task.Run(SaveCache);
+    }
 }


### PR DESCRIPTION
- Replace ConcurrentDictionary with LinkedList+Dictionary LRU
- Save cache as JSON to ConfigDirectory on each new entry and dispose
- Load cache on plugin init, capped to MAX_CACHE_SIZE tail entries
- Fix concurrent write-back: move existing node to tail instead of skip

---

该 PR 主要针对翻译缓存功能做了如下改进：

1. 将翻译缓存保存在插件数据目录 `C:\Users\${USERNAME}\AppData\Roaming\XIVLauncher\pluginConfigs\ChatTranslated\translation_cache.json`，并且在插件初始化时读取。
2. 优化缓存自动清理功能，在超出最大缓存数（120）时，只删除最旧的一条缓存。
3. 优化高频翻译缓存，遇到已存在的原文 Key 时，将其移动到缓存列表的末尾（即视作最新的缓存内容）。减少因缓存自动清理而重新请求 LLM 的情况发生。