### PR TITLE
Add configurable translation caching with UI toggle

### DIFF
--- a/ChatTranslated/Configuration.cs
+++ b/ChatTranslated/Configuration.cs
@@ -81,6 +81,8 @@ public class Configuration : IPluginConfiguration
     public bool UseCustomPrompt { get; set; } = false;
     public string LLM_CustomPrompt { get; set; } = "";
 
+    public bool EnableTranslationCache { get; set; } = true;
+
     public string MagicString { get; set; } = "";
 
     public void Save()

--- a/ChatTranslated/Translate/TranslationHandler.cs
+++ b/ChatTranslated/Translate/TranslationHandler.cs
@@ -95,14 +95,19 @@ internal static class TranslationHandler
     {
         targetLanguage ??= Service.configuration.EffectiveTargetLanguage;
 
-        lock (TranslationCacheLock)
+        var cacheEnabled = Service.configuration.EnableTranslationCache;
+
+        if (cacheEnabled)
         {
-            if (TranslationCacheIndex.TryGetValue(message.OriginalText, out var cachedNode))
+            lock (TranslationCacheLock)
             {
-                TranslationCache.Remove(cachedNode);
-                TranslationCache.AddLast(cachedNode);
-                message.TranslatedContent = cachedNode.Value.Value;
-                return message;
+                if (TranslationCacheIndex.TryGetValue(message.OriginalText, out var cachedNode))
+                {
+                    TranslationCache.Remove(cachedNode);
+                    TranslationCache.AddLast(cachedNode);
+                    message.TranslatedContent = cachedNode.Value.Value;
+                    return message;
+                }
             }
         }
 
@@ -124,7 +129,8 @@ internal static class TranslationHandler
         message.TranslatedContent = translatedText;
         message.TranslationMode = mode;
 
-        if (message.Source != MessageSource.MainWindow
+        if (cacheEnabled
+            && message.Source != MessageSource.MainWindow
             && message.TranslationMode != Configuration.TranslationMode.MachineTranslate)
         {
             bool added;

--- a/ChatTranslated/Windows/ConfigTabs/TranslationModeTab.cs
+++ b/ChatTranslated/Windows/ConfigTabs/TranslationModeTab.cs
@@ -11,6 +11,7 @@ public class TranslationModeTab
     public void Draw(Configuration configuration)
     {
         DrawEngineSelection(configuration);
+        DrawCacheToggle(configuration);
 
         ImGui.Separator();
         ImGui.Spacing();
@@ -48,6 +49,21 @@ public class TranslationModeTab
             TranslationHandler.ClearTranslationCache();
             configuration.Save();
         }
+    }
+
+    internal static void DrawCacheToggle(Configuration configuration)
+    {
+        var enableCache = configuration.EnableTranslationCache;
+        if (ImGui.Checkbox("Cache translations", ref enableCache))
+        {
+            configuration.EnableTranslationCache = enableCache;
+            configuration.Save();
+            if (!enableCache)
+                TranslationHandler.ClearTranslationCache();
+        }
+
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Reuse previous translations for identical messages (up to 120 entries, persisted to disk).\nDisable to always re-translate.");
     }
 
     internal static void DrawLLMConfiguration(Configuration configuration)


### PR DESCRIPTION
## Summary
This PR adds a configurable translation cache feature that allows users to enable or disable caching of translations. The cache is enabled by default and can be toggled via a new UI control in the Translation Mode settings tab.

## Key Changes
- **Configuration**: Added `EnableTranslationCache` boolean property (defaults to `true`) to persist cache preference
- **Translation Handler**: Wrapped cache lookup logic with a conditional check based on the configuration setting, allowing the cache to be bypassed when disabled
- **UI Control**: Added `DrawCacheToggle()` method to the Translation Mode tab that:
  - Displays a checkbox to enable/disable translation caching
  - Automatically saves configuration changes
  - Clears the cache when disabled by the user
  - Includes a tooltip explaining the cache behavior (120 entries, disk persistence)

## Implementation Details
- Cache checking is now guarded by `cacheEnabled` flag, preventing unnecessary lock acquisition when caching is disabled
- When users disable caching, `TranslationHandler.ClearTranslationCache()` is called to free up memory
- The cache remains functional for all message sources except MainWindow, and only for non-machine-translation modes (existing behavior preserved)
- Configuration changes are immediately persisted to disk

https://claude.ai/code/session_0111soUz9ANXi6zJKXaU7Dh2