### PR TITLE
Refactor MainWindow language handling and improve error handling

### DIFF
--- a/ChatTranslated/Windows/MainWindow.cs
+++ b/ChatTranslated/Windows/MainWindow.cs
@@ -2,6 +2,7 @@ using ChatTranslated.Chat;
 using ChatTranslated.Localization;
 using ChatTranslated.Translate;
 using ChatTranslated.Utils;
+using ChatTranslated.Windows.ConfigTabs;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
@@ -19,7 +20,7 @@ public partial class MainWindow : Window
 {
     private static readonly StringBuilder sb = new();
     private static readonly Lock sbLock = new();
-    private readonly string[] languages = ["Japanese", "English", "German", "French"];
+    private static readonly string[] languages = LanguagesTab.SupportedLanguages;
 
     internal string outputText = "";
     internal string inputText = "";
@@ -86,9 +87,15 @@ public partial class MainWindow : Window
 
     private void DrawInputField(float scale)
     {
-        int langIndex = Math.Max(0, Array.IndexOf(languages, Service.configuration.SelectedMainWindowTargetLanguage));
+        int langIndex = Array.IndexOf(languages, Service.configuration.SelectedMainWindowTargetLanguage);
+        if (langIndex < 0)
+        {
+            langIndex = 0;
+            Service.configuration.SelectedMainWindowTargetLanguage = languages[0];
+            Service.configuration.Save();
+        }
         string[] localizedLangs = [.. languages.Select(l => Resources.ResourceManager.GetString(l, Resources.Culture) ?? l)];
-        ImGui.SetNextItemWidth(80 * scale);
+        ImGui.SetNextItemWidth(140 * scale);
         if (ImGui.Combo("##LanguageCombo", ref langIndex, localizedLangs, languages.Length))
         {
             Service.configuration.SelectedMainWindowTargetLanguage = languages[langIndex];
@@ -104,7 +111,7 @@ public partial class MainWindow : Window
             if (!string.IsNullOrWhiteSpace(inputText))
             {
                 var message = new Message(null!, MessageSource.MainWindow, inputText) { Context = "null" };
-                Task.Run(() => ProcessInputAsync(message));
+                _ = ProcessInputAsync(message);
                 inputText = "";
             }
         }
@@ -126,21 +133,30 @@ public partial class MainWindow : Window
         ImGui.TextUnformatted(reverseTranslatedText);
     }
 
-    private async void ProcessInputAsync(Message message)
+    private async Task ProcessInputAsync(Message message)
     {
-        var translatedMessage = await TranslationHandler.TranslateMessage(message, Service.configuration.SelectedMainWindowTargetLanguage);
-
-        if (translatedMessage.TranslatedContent == null)
+        try
         {
+            var translatedMessage = await TranslationHandler.TranslateMessage(message, Service.configuration.SelectedMainWindowTargetLanguage);
+
+            if (translatedMessage.TranslatedContent == null)
+            {
+                translatedText = Resources.Main_Window_Translation_Failed;
+                reverseTranslatedText = "";
+                return;
+            }
+
+            translatedText = translatedMessage.TranslatedContent;
+
+            var (reverseText, _) = await MachineTranslate.Translate(translatedMessage.TranslatedContent, Service.configuration.SelectedPluginLanguage);
+            reverseTranslatedText = reverseText;
+        }
+        catch (Exception ex)
+        {
+            Service.pluginLog.Warning($"[MainWindow] Translation failed: {ex.Message}");
             translatedText = Resources.Main_Window_Translation_Failed;
             reverseTranslatedText = "";
-            return;
         }
-
-        translatedText = translatedMessage.TranslatedContent;
-
-        var (reverseText, _) = await MachineTranslate.Translate(translatedMessage.TranslatedContent, Service.configuration.SelectedPluginLanguage);
-        reverseTranslatedText = reverseText;
     }
 
     public void PrintToOutput(string message)


### PR DESCRIPTION
## Summary
This PR refactors the language selection logic in MainWindow to use a centralized language list from LanguagesTab, improves error handling in the translation process, and makes several code quality improvements.

## Key Changes
- **Language list centralization**: Replace hardcoded language array with `LanguagesTab.SupportedLanguages` to maintain a single source of truth
- **Improved language index validation**: Add explicit bounds checking with fallback to default language (index 0) and configuration persistence when an invalid language is detected
- **Enhanced error handling**: Wrap `ProcessInputAsync` logic in try-catch block to gracefully handle translation failures and log warnings
- **Method signature fix**: Change `ProcessInputAsync` from `async void` to `async Task` for proper async pattern compliance and better error handling
- **UI improvements**: Increase language combo box width from 80 to 140 scale units for better visibility
- **Code cleanup**: Replace `Task.Run()` with direct `await` pattern using discard operator (`_ =`) for cleaner async execution

## Notable Implementation Details
- Invalid language selections now trigger automatic configuration save to persist the corrected default language
- Translation failures are now caught and logged with descriptive warning messages instead of silently failing
- The async method now properly returns a Task, allowing callers to await completion if needed

https://claude.ai/code/session_01JNRQAW7NX2ATAiSbRKcAfw