### PR TITLE
Add button to clear translation cache

### DIFF
--- a/ChatTranslated/Windows/ConfigTabs/TranslationModeTab.cs
+++ b/ChatTranslated/Windows/ConfigTabs/TranslationModeTab.cs
@@ -64,6 +64,13 @@ public class TranslationModeTab
 
         if (ImGui.IsItemHovered())
             ImGui.SetTooltip("Reuse previous translations for identical messages (up to 120 entries, persisted to disk).\nDisable to always re-translate.");
+
+        ImGui.SameLine();
+        if (ImGui.Button("Clear cache"))
+            TranslationHandler.ClearTranslationCache();
+
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Remove all cached translations.");
     }
 
     internal static void DrawLLMConfiguration(Configuration configuration)


### PR DESCRIPTION
## Summary
Added a "Clear cache" button to the Translation Mode configuration tab, allowing users to manually remove all cached translations without disabling the cache feature entirely.

## Key Changes
- Added a new "Clear cache" button next to the cache toggle in the TranslationModeTab UI
- Button invokes `TranslationHandler.ClearTranslationCache()` when clicked
- Included a tooltip explaining the button's functionality: "Remove all cached translations."

## Implementation Details
- The button is positioned on the same line as the cache toggle using `ImGui.SameLine()`
- Follows the existing UI pattern with a tooltip for user guidance
- Provides users with more granular control over the translation cache without requiring a full disable/enable cycle

https://claude.ai/code/session_01KcF58PzL8d2yK9u3gEhf7X